### PR TITLE
Update ci to use submodule version of saci-database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
           python-version: "3.11"
-      - name: Update private key
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install .[tests]
-          # Install saci-database
-          ACTIVE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          git clone git@github.com:senpai-on-fire/saci-database.git
-          (cd saci-database && git checkout $ACTIVE_BRANCH && pip install .)
+          pip install ./saci-database
 
       - name: Pytest
         run: |


### PR DESCRIPTION
CI currently tests using the latest commit of the same branch in saci-database, but when the container is built, it uses the submodule version. This caused the container to be built and published with an old version of saci-database that was not compatible and caused an error on import. I think we should always use the submodule version.